### PR TITLE
don't wait by default

### DIFF
--- a/lib/feed_pub/run.rb
+++ b/lib/feed_pub/run.rb
@@ -12,8 +12,12 @@ module FeedPub::Run
     end
 
     def call(url, output:, filepath:, max_pages: DEFAULT_MAX_PAGES)
+      Capybara.predicates_wait = false
       session = Capybara::Session.new(driver)
       session.visit(url)
+
+      raise "No images on page" unless session.has_css?("img", wait: 5)
+
       image_selector = infer_image_selector(session, output:)
       next_selector = FeedPub::InferNextSelector.call(session, output:)
       self.processed_urls = []

--- a/spec/feed_pub/run_spec.rb
+++ b/spec/feed_pub/run_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe FeedPub::Run do
 
   it "raises an error when no images are found" do
     expect { described_class.call("no_images", output: StringIO.new, filepath:) }
+      .to raise_error("No images on page")
+  end
+
+  it "raises an error when no image candidates are found" do
+    expect { described_class.call("no_matching_image", output: StringIO.new, filepath:) }
       .to raise_error("No image candidates found")
   end
 

--- a/spec/fixtures/no_matching_image.html
+++ b/spec/fixtures/no_matching_image.html
@@ -1,0 +1,4 @@
+<div>
+  <img width='300' src="https://foo.png"></img>
+  <div id='next'></div>
+</div>


### PR DESCRIPTION
Things should pretty much always be on the page already, so waiting just
slows the process down. We want to fail fast if what we're looking for
is not present.
