### PR TITLE
add TestNode.wrap method

### DIFF
--- a/spec/feed_pub/next_selector/infer_spec.rb
+++ b/spec/feed_pub/next_selector/infer_spec.rb
@@ -2,13 +2,13 @@
 
 RSpec.describe FeedPub::NextSelector::Infer do
   it "returns a link selector when a link with 'Next' is found" do
-    session = TestNode.new("<a href='/foo'>Next</a>")
+    session = TestNode.wrap("<a href='/foo'>Next</a>")
 
     expect(described_class.call(session)).to be_a(FeedPub::NextSelector::Link)
   end
 
   it "returns an alt selector when an element with 'next' in alt is found" do
-    session = TestNode.new("<button alt='next'></button>")
+    session = TestNode.wrap("<button alt='next'></button>")
 
     selector = described_class.call(session)
 
@@ -16,7 +16,7 @@ RSpec.describe FeedPub::NextSelector::Infer do
   end
 
   it "returns a class selector when an element with 'next' in class is found" do
-    session = TestNode.new("<button class='next'></button>")
+    session = TestNode.wrap("<button class='next'></button>")
 
     selector = described_class.call(session)
 

--- a/spec/feed_pub/next_selector/link_spec.rb
+++ b/spec/feed_pub/next_selector/link_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe FeedPub::NextSelector::Link do
   describe "#matches?" do
     it "returns true when the link is found" do
       selector = described_class.new("Next")
-      session = TestNode.new("<a href='/foo'>Next</a>")
+      session = TestNode.wrap("<a href='/foo'>Next</a>")
 
       expect(selector.matches?(session)).to be(true)
     end
 
     it "returns false when the link is not found" do
       selector = described_class.new("Next")
-      session = TestNode.new("<a href='/foo'>Foo</a>")
+      session = TestNode.wrap("<a href='/foo'>Foo</a>")
 
       expect(selector.matches?(session)).to be(false)
     end
@@ -19,7 +19,7 @@ RSpec.describe FeedPub::NextSelector::Link do
 
   describe "#click" do
     it "clicks the link" do
-      session = TestNode.new("<a href='next'></a>")
+      session = TestNode.wrap("<a href='next'></a>")
       expect(session).to receive(:visit).with("next")
 
       described_class.new("").click(session)

--- a/spec/support/test_driver.rb
+++ b/spec/support/test_driver.rb
@@ -15,11 +15,11 @@ class TestDriver
   end
 
   def find_css(selector, _options)
-    body.find_css(selector).map { |element| TestNode.new(element) }
+    body.find_css(selector).map { |element| TestNode.wrap(element) }
   end
 
   def find_xpath(selector)
-    body.find_xpath(selector).map { |element| TestNode.new(element) }
+    body.find_xpath(selector).map { |element| TestNode.wrap(element) }
   end
 
   def wait?
@@ -38,19 +38,20 @@ end
 class TestNode
   attr_accessor :element
 
+  class << self
+    def wrap(element)
+      new(Capybara::Node::Simple.new(element))
+    end
+  end
+
   def initialize(element)
-    self.element =
-      if element.is_a?(Capybara::Node::Simple)
-        element
-      else
-        Capybara::Node::Simple.new(element)
-      end
+    self.element = element
   end
 
   def click(*_args); end
 
   def find_css(selector)
-    element.find_css(selector).map { |element| TestNode.new(element) }
+    element.find_css(selector).map { |element| TestNode.wrap(element) }
   end
 
   def all(selector)


### PR DESCRIPTION
This is a bit more explicit. Sometimes we have a String, others we start
with a `Capybara::Node::Simple`, and yet others we're dealing with a
`Nokogiri` element. For the cases when we're already starting with a
`Simple` we can call `new`, but for cases where we need to wrap it we
can call `wrap`.
