### PR TITLE
split up NextSelector attributes

### DIFF
--- a/lib/feed_pub/next_selector/attribute.rb
+++ b/lib/feed_pub/next_selector/attribute.rb
@@ -1,19 +1,26 @@
 # frozen_string_literal: true
 
 class FeedPub::NextSelector::Attribute
-  def initialize(selector)
-    @selector = selector
+  attr_accessor :attribute, :term
+
+  def initialize(attribute, term)
+    self.attribute = attribute
+    self.term = term
   end
 
   def matches?(session)
-    session.has_css?(@selector)
+    session.has_css?(value)
   end
 
   def click(session)
-    session.find(@selector).click
+    session.find(value).click
   end
 
   def to_s
-    @selector
+    value
+  end
+
+  def value
+    "[#{@attribute}*='#{@term}']"
   end
 end

--- a/lib/feed_pub/next_selector/infer.rb
+++ b/lib/feed_pub/next_selector/infer.rb
@@ -3,9 +3,9 @@
 module FeedPub::NextSelector::Infer
   SELECTORS = [
     FeedPub::NextSelector::Link.new("Next"),
-    FeedPub::NextSelector::Attribute.new("[id*='next']"),
-    FeedPub::NextSelector::Attribute.new("[class*='next']"),
-    FeedPub::NextSelector::Attribute.new("[alt*='next']"),
+    FeedPub::NextSelector::Attribute.new("id", "next"),
+    FeedPub::NextSelector::Attribute.new("class", "next"),
+    FeedPub::NextSelector::Attribute.new("alt", "next"),
   ].freeze
 
   class << self


### PR DESCRIPTION
This will allow us to generate a more specific selector after we've
found it.
